### PR TITLE
Bootstraped the DAV Client

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,21 @@
+{
+  "root": true,
+  "parser": "@typescript-eslint/parser",
+  "plugins": [
+    "@typescript-eslint"
+  ],
+  "extends": [
+    "eslint:recommended",
+    "plugin:@typescript-eslint/recommended"
+  ],
+  "env": {
+    "browser": true,
+    "es6": true,
+    "node": true,
+    "commonjs": true
+  },
+  "rules": {
+    "quotes": ["error", "single"],
+    "indent": ["error", 2]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+node_modules/
+build/
+dist/
+.env
+.vscode
+package-lock.json

--- a/README.md
+++ b/README.md
@@ -1,1 +1,56 @@
 # DAV Client
+
+A DAV client to send requests to DAV servers.
+
+## Usage
+
+Here's an example usage:
+
+```javascript
+import { DAVClient, getInbox, HTTPFetchClient } from 'dav-client';
+
+const [username, password] = ['admin@open-paas.org', 'secret'];
+const httpClient = new HTTPFetchClient();
+const davClient = new DAVClient({ baseURL: 'http://0.0.0.0:8001', httpClient, headers: { Authorization: `Basic ${Buffer.from([username, password].join(':')).toString('base64')}`} });
+
+getInbox(davClient)('5f60334e78d1b021351f9f6e')
+  .then(inbox => {
+    console.log('inbox =', inbox);
+  });
+```
+
+You can replace the default `HTTPFetchClient` (which uses [the Fetch API](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API)) with any http client as long as it follows the following interface:
+
+```typescript
+export interface RequestOptions {
+  url: string;
+  method: string;
+  params?: Record<string, unknown>;
+  headers?: HeadersInit;
+  body?: BodyInit | null;
+}
+
+export interface HTTPClient {
+  request(options: RequestOptions): Promise<Response>;
+  requestJson<T>(options: RequestOptions): Promise<T>;
+  requestText(options: RequestOptions): Promise<string>;
+}
+```
+
+## Build
+
+To build the library, run the following command:
+
+```bash
+npm run build
+```
+
+The built code will reside in the **./build/** folder.
+
+## Test
+
+To run tests, run the following command:
+
+```bash
+npm run test
+```

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+};

--- a/lib/DAVClient.ts
+++ b/lib/DAVClient.ts
@@ -1,0 +1,43 @@
+import urlJoin from 'url-join';
+import { RequestOptions, HTTPClient } from './HTTPClient';
+
+interface DAVClientConstructorOptions {
+  baseURL: string;
+  httpClient: HTTPClient;
+  headers?: HeadersInit;
+}
+
+export class DAVClient {
+  #baseURL: string;
+  #httpClient: HTTPClient;
+  #headers?: HeadersInit;
+
+  constructor({ baseURL, httpClient, headers }: DAVClientConstructorOptions) {
+    this.#baseURL = baseURL;
+    this.#httpClient = httpClient;
+
+    if (headers) {
+      this.#headers = headers;
+    }
+  }
+
+  private buildRequestOptions(options: RequestOptions): RequestOptions {
+    return {
+      ...options,
+      url: this.buildFullURL(options.url),
+      headers: { ...options.headers, ...this.#headers } 
+    };
+  }
+
+  private buildFullURL(url: string) {
+    return urlJoin(this.#baseURL, url);
+  }
+
+  public requestJson<T>(options: RequestOptions): Promise<T> {
+    return this.#httpClient.requestJson<T>(this.buildRequestOptions(options));
+  }
+
+  public requestText(options: RequestOptions): Promise<string> {
+    return this.#httpClient.requestText(this.buildRequestOptions(options));
+  }
+}

--- a/lib/HTTPClient.ts
+++ b/lib/HTTPClient.ts
@@ -1,0 +1,13 @@
+export interface RequestOptions {
+  url: string;
+  method: string;
+  params?: Record<string, unknown>;
+  headers?: HeadersInit;
+  body?: BodyInit | null;
+}
+
+export interface HTTPClient {
+  request(options: RequestOptions): Promise<Response>;
+  requestJson<T>(options: RequestOptions): Promise<T>;
+  requestText(options: RequestOptions): Promise<string>;
+}

--- a/lib/HTTPFetchClient.ts
+++ b/lib/HTTPFetchClient.ts
@@ -1,0 +1,43 @@
+import fetch from 'isomorphic-unfetch';
+import { HTTPClient, RequestOptions } from './HTTPClient';
+
+interface FetchOptions {
+  method: string;
+  body?: BodyInit | null;
+  headers?: HeadersInit;
+}
+
+export class HTTPFetchClient implements HTTPClient {
+  private buildFetchOptions({ method, body, headers }: RequestOptions): FetchOptions {
+    const fetchOptions: FetchOptions = {
+      method
+    };
+
+    if (body) fetchOptions.body = body;
+    if (headers) fetchOptions.headers = headers;
+
+    return fetchOptions;
+  }
+
+  public request(options: RequestOptions): Promise<Response> {
+    const fetchOptions = this.buildFetchOptions(options);
+
+    return fetch(options.url, fetchOptions);
+  }
+
+  public async requestJson<T>(options: RequestOptions): Promise<T> {
+    const response = await this.request(options);
+
+    const jsonBodyContent = await response.json();
+
+    return jsonBodyContent;
+  }
+
+  public async requestText(options: RequestOptions): Promise<string> {
+    const response = await this.request(options);
+
+    const textBodyContent = await response.text();
+
+    return textBodyContent;
+  }
+}

--- a/lib/api/calendars.ts
+++ b/lib/api/calendars.ts
@@ -1,0 +1,24 @@
+import { DAVClient } from '../DAVClient';
+
+const BASE_PATH = '/calendars';
+
+export const getInbox = (client: DAVClient) => async (userId: string): Promise<string> => {
+  return client.requestText({
+    url: `${BASE_PATH}/${userId}/inbox`,
+    method: 'REPORT',
+    headers: {
+      Depth: '1'
+    },
+    body: `<c:calendar-query
+            xmlns:d="DAV:"
+            xmlns:c="urn:ietf:params:xml:ns:caldav">
+            <d:prop>
+              <d:getetag />
+              <c:calendar-data />
+            </d:prop>
+            <c:filter>
+              <c:comp-filter name="VCALENDAR" />
+            </c:filter>
+          </c:calendar-query>`
+  });
+}

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,0 +1,9 @@
+import { HTTPFetchClient } from './HTTPFetchClient';
+import { DAVClient } from './DAVClient';
+import { getInbox } from './api/calendars';
+
+export {
+  HTTPFetchClient,
+  DAVClient,
+  getInbox
+};

--- a/package.json
+++ b/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "dav-client",
+  "version": "0.0.1",
+  "description": "A DAV client to connect to DAV servers",
+  "main": "dist/index.js",
+  "module": "dist/index.js",
+  "type": "module",
+  "scripts": {
+    "build": "rollup -c rollup.config.ts",
+    "test": "jest"
+  },
+  "devDependencies": {
+    "@rollup/plugin-commonjs": "^17.1.0",
+    "@rollup/plugin-node-resolve": "^11.2.0",
+    "@rollup/plugin-typescript": "^8.2.0",
+    "@tsconfig/recommended": "^1.0.1",
+    "@types/jest": "^26.0.21",
+    "@types/url-join": "^4.0.0",
+    "@typescript-eslint/eslint-plugin": "^4.18.0",
+    "@typescript-eslint/parser": "^4.18.0",
+    "eslint": "^7.22.0",
+    "jest": "^26.6.3",
+    "rollup": "^2.42.0",
+    "rollup-plugin-terser": "^7.0.2",
+    "rollup-plugin-typescript2": "^0.30.0",
+    "ts-jest": "^26.5.4",
+    "tslib": "^2.1.0",
+    "typescript": "^4.2.3"
+  },
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "isomorphic-unfetch": "^3.1.0",
+    "url-join": "^4.0.1"
+  }
+}

--- a/rollup.config.ts
+++ b/rollup.config.ts
@@ -1,0 +1,25 @@
+import commonjs from '@rollup/plugin-commonjs';
+import resolve from '@rollup/plugin-node-resolve';
+import { terser } from 'rollup-plugin-terser';
+import typescript from '@rollup/plugin-typescript';
+import pkg from './package.json';
+
+export default {
+  input: 'lib/index.ts',
+  output: {
+    file: pkg.main,
+    format: 'es',
+    sourcemap: true
+  },
+  plugins: [
+    resolve(),
+    commonjs(),
+    typescript({
+      sourceMap: true,
+      declaration: true,
+      declarationDir: '.',
+      tsconfig: './tsconfig.json'
+    }),
+    terser()
+  ]
+};

--- a/test/DAVClient.test.ts
+++ b/test/DAVClient.test.ts
@@ -1,0 +1,38 @@
+import { DAVClient } from '../lib/DAVClient';
+import { HTTPClient, RequestOptions } from '../lib/HTTPClient';
+
+describe('The DAVClient class', () => {
+  let httpClient: HTTPClient;
+
+  beforeEach(() => {
+    httpClient = {
+      request: jest.fn(),
+      requestJson: jest.fn(),
+      requestText: jest.fn()
+    };
+  });
+
+  describe('The requestJson method', () => {
+    it('should send a request using the requestJson method of the http client with correct params', () => {
+      const requestOptions: RequestOptions = { url: '/api/test', method: 'GET', headers: { Depth: '1' } };
+      const davClient = new DAVClient({ baseURL: 'http://url.com/', httpClient, headers: { Authorization: 'Bearer token' } });
+
+      davClient.requestJson(requestOptions);
+
+      expect(httpClient.requestJson).toHaveBeenCalledTimes(1);
+      expect(httpClient.requestJson).toHaveBeenCalledWith({ url: 'http://url.com/api/test', method: 'GET', headers: { Authorization: 'Bearer token', Depth: '1' } });
+    });
+  });
+
+  describe('The requestText method', () => {
+    it('should send a request using the requestText method of the http client with correct params', () => {
+      const requestOptions: RequestOptions = { url: '/api/test', method: 'GET', headers: { Depth: '1' } };
+      const davClient = new DAVClient({ baseURL: 'http://url.com/', httpClient, headers: { Authorization: 'Bearer token' } });
+
+      davClient.requestText(requestOptions);
+
+      expect(httpClient.requestText).toHaveBeenCalledTimes(1);
+      expect(httpClient.requestText).toHaveBeenCalledWith({ url: 'http://url.com/api/test', method: 'GET', headers: { Authorization: 'Bearer token', Depth: '1' } });
+    });
+  });
+});

--- a/test/HTTPFetchClient.test.ts
+++ b/test/HTTPFetchClient.test.ts
@@ -1,0 +1,138 @@
+import { HTTPFetchClient } from '../lib/HTTPFetchClient';
+import fetch from 'isomorphic-unfetch';
+import { RequestOptions } from '../lib/HTTPClient';
+
+jest.mock('isomorphic-unfetch', () => jest.fn());
+
+describe('The HTTPFetchClient class', () => {
+  const fetchMockReturnValue: Partial<Response> = {};
+
+  beforeEach(() => {
+    fetchMockReturnValue.json = () => Promise.resolve({});
+    fetchMockReturnValue.text = () => Promise.resolve('');
+
+    (fetch as jest.Mock).mockReturnValue(Promise.resolve(fetchMockReturnValue));
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('The request method', () => {
+    it('should send a fetch request with the correct params without headers and body', async () => {
+      const httpFetchClient = new HTTPFetchClient();
+      const requestOptions: RequestOptions = { url: 'http://url.com', method: 'GET' };
+
+      await httpFetchClient.request(requestOptions);
+
+      expect(fetch).toHaveBeenCalledTimes(1);
+      expect(fetch).toHaveBeenCalledWith(requestOptions.url, { method: requestOptions.method });
+    });
+
+    it('should send a fetch request with the correct params with headers but without body', async () => {
+      const httpFetchClient = new HTTPFetchClient();
+      const requestOptions: RequestOptions = { url: 'http://url.com', method: 'GET', headers: { Authorization: 'Bearer whatever' } };
+
+      await httpFetchClient.request(requestOptions);
+
+      expect(fetch).toHaveBeenCalledTimes(1);
+      expect(fetch).toHaveBeenCalledWith(requestOptions.url, { method: requestOptions.method, headers: requestOptions.headers });
+    });
+
+    it('should send a fetch request with the correct params with headers and body', async () => {
+      const httpFetchClient = new HTTPFetchClient();
+      const requestOptions: RequestOptions = { url: 'http://url.com', method: 'POST', headers: { Authorization: 'Bearer whatever' }, body: '{"a":1}' };
+
+      await httpFetchClient.request(requestOptions);
+
+      expect(fetch).toHaveBeenCalledTimes(1);
+      expect(fetch).toHaveBeenCalledWith(requestOptions.url, { method: requestOptions.method, headers: requestOptions.headers, body: requestOptions.body });
+    });
+  });
+
+  describe('The requestJson method', () => {
+    let jsonBodyContent: Record<string, unknown>;
+
+    beforeEach(() => {
+      jsonBodyContent = { a: 'b' };
+
+      fetchMockReturnValue.json = () => Promise.resolve(jsonBodyContent);
+    });
+    
+    it('should send a fetch request with the correct params without headers and body and return json content', async () => {
+      const httpFetchClient = new HTTPFetchClient();
+      const requestOptions: RequestOptions = { url: 'http://url.com', method: 'GET' };
+
+      const result = await httpFetchClient.requestJson(requestOptions);
+
+      expect(fetch).toHaveBeenCalledTimes(1);
+      expect(fetch).toHaveBeenCalledWith(requestOptions.url, { method: requestOptions.method });
+      expect(result).toBe(jsonBodyContent);
+    });
+
+    it('should send a fetch request with the correct params with headers but without body and return json content', async () => {
+      const httpFetchClient = new HTTPFetchClient();
+      const requestOptions: RequestOptions = { url: 'http://url.com', method: 'GET', headers: { Authorization: 'Bearer whatever' } };
+
+      const result = await httpFetchClient.requestJson(requestOptions);
+
+      expect(fetch).toHaveBeenCalledTimes(1);
+      expect(fetch).toHaveBeenCalledWith(requestOptions.url, { method: requestOptions.method, headers: requestOptions.headers });
+      expect(result).toBe(jsonBodyContent);
+    });
+
+    it('should send a fetch request with the correct params with headers and body and return json content', async () => {
+      const httpFetchClient = new HTTPFetchClient();
+      const requestOptions: RequestOptions = { url: 'http://url.com', method: 'POST', headers: { Authorization: 'Bearer whatever' }, body: '{"a":1}' };
+
+      const result = await httpFetchClient.requestJson(requestOptions);
+
+      expect(fetch).toHaveBeenCalledTimes(1);
+      expect(fetch).toHaveBeenCalledWith(requestOptions.url, { method: requestOptions.method, headers: requestOptions.headers, body: requestOptions.body });
+      expect(result).toBe(jsonBodyContent);
+    });
+  });
+
+  describe('The requestText method', () => {
+    let textBodyContent: string;
+
+    beforeEach(() => {
+      textBodyContent = '<xml></xml>';
+
+      fetchMockReturnValue.text = () => Promise.resolve(textBodyContent);
+    });
+    
+    it('should send a fetch request with the correct params without headers and body and return text content', async () => {
+      const httpFetchClient = new HTTPFetchClient();
+      const requestOptions: RequestOptions = { url: 'http://url.com', method: 'GET' };
+
+      const result = await httpFetchClient.requestText(requestOptions);
+
+      expect(fetch).toHaveBeenCalledTimes(1);
+      expect(fetch).toHaveBeenCalledWith(requestOptions.url, { method: requestOptions.method });
+      expect(result).toBe(textBodyContent);
+    });
+
+    it('should send a fetch request with the correct params with headers but without body and return text content', async () => {
+      const httpFetchClient = new HTTPFetchClient();
+      const requestOptions: RequestOptions = { url: 'http://url.com', method: 'GET', headers: { Authorization: 'Bearer whatever' } };
+
+      const result = await httpFetchClient.requestText(requestOptions);
+
+      expect(fetch).toHaveBeenCalledTimes(1);
+      expect(fetch).toHaveBeenCalledWith(requestOptions.url, { method: requestOptions.method, headers: requestOptions.headers });
+      expect(result).toBe(textBodyContent);
+    });
+
+    it('should send a fetch request with the correct params with headers and body and return text content', async () => {
+      const httpFetchClient = new HTTPFetchClient();
+      const requestOptions: RequestOptions = { url: 'http://url.com', method: 'POST', headers: { Authorization: 'Bearer whatever' }, body: '{"a":1}' };
+
+      const result = await httpFetchClient.requestText(requestOptions);
+
+      expect(fetch).toHaveBeenCalledTimes(1);
+      expect(fetch).toHaveBeenCalledWith(requestOptions.url, { method: requestOptions.method, headers: requestOptions.headers, body: requestOptions.body });
+      expect(result).toBe(textBodyContent);
+    });
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "@tsconfig/recommended/tsconfig.json",
+  "include": ["lib/**/*"],
+  "exclude": ["node_modules/*"]
+}


### PR DESCRIPTION
Resolves https://github.com/OpenPaaS-Suite/esn-frontend-calendar/issues/472.

- [x] Write tests (Jest)

**=========== README.md ===========**

# DAV Client

A DAV client to send requests to DAV servers.

## Usage

Here's an example usage:

```javascript
import { DAVClient, getInbox, HTTPFetchClient } from 'dav-client';

const [username, password] = ['admin@open-paas.org', 'secret'];
const httpClient = new HTTPFetchClient();
const davClient = new DAVClient({ baseURL: 'http://0.0.0.0:8001', httpClient, headers: { Authorization: `Basic ${Buffer.from([username, password].join(':')).toString('base64')}`} });

getInbox(davClient)('5f60334e78d1b021351f9f6e')
  .then(inbox => {
    console.log('inbox =', inbox);
  });
```

You can replace the default `HTTPFetchClient` (which uses [the Fetch API](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API)) with any http client as long as it follows the following interface:

```typescript
export interface RequestOptions {
  url: string;
  method: string;
  params?: Record<string, unknown>;
  headers?: HeadersInit;
  body?: BodyInit | null;
}

export interface HTTPClient {
  request(options: RequestOptions): Promise<Response>;
  requestJson<T>(options: RequestOptions): Promise<T>;
  requestText(options: RequestOptions): Promise<string>;
}
```

## Build

To build the library, run the following command:

```bash
npm run build
```

The built code will reside in the **./build/** folder.

## Test

To run tests, run the following command:

```bash
npm run test
```
